### PR TITLE
Make fetcher Send + Sync

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -37,7 +37,7 @@ enum Inner {
 
 impl From<(Credentials, &Config)> for Inner {
     fn from((credentials, config): (Credentials, &Config)) -> Self {
-        let fetcher: Box<dyn Fetcher> = match credentials {
+        let fetcher: Box<dyn Fetcher + Send + Sync> = match credentials {
             Credentials::None => return Self::None,
             Credentials::ApiKey(key) => return Self::ApiKey(api_key::ApiKey::new(key)),
             Credentials::User(user) => Box::new(User::new(user)),

--- a/src/auth/oauth2/mod.rs
+++ b/src/auth/oauth2/mod.rs
@@ -32,7 +32,7 @@ pub(super) struct Oauth2 {
 }
 
 impl Oauth2 {
-    pub fn new(fetcher: Box<dyn token::Fetcher>, max_retry: u8) -> Self {
+    pub fn new(fetcher: Box<dyn token::Fetcher + Send + Sync>, max_retry: u8) -> Self {
         Self {
             inner: Arc::new(RwLock::new(Inner { state: State::NotFetched, fetcher, max_retry })),
         }
@@ -60,7 +60,7 @@ impl fmt::Debug for Oauth2 {
 
 struct Inner {
     state: State,
-    fetcher: Box<dyn token::Fetcher>,
+    fetcher: Box<dyn token::Fetcher + Send + Sync>,
     max_retry: u8,
 }
 


### PR DESCRIPTION
Otherwise it's not possible to create a client like `PublisherClient<GoogleAuthz<Channel>>` and pass it as part of a larger task to `tokio::spawn` since spawning requires the task be Send + Sync

Thanks for putting together this library!
