### PR TITLE
Reduce unwraps in GoogleAuthz channel builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ This library provides auto-renewed tokens for Google service authentication.<br>
 use google_authz::{Credentials, GoogleAuthz};
 
 let credentials = Credentials::builder().build().await.unwrap();
-let service = GoogleAuthz::builder(service).credentials(credentials).build().await;
+let service = GoogleAuthz::builder(service).credentials(credentials).build().await.unwrap();
 
 // same as above
-let service = GoogleAuthz::new(service).await;
+let service = GoogleAuthz::try_new(service).await.unwrap();
 ```
 
 
@@ -45,37 +45,37 @@ let service = GoogleAuthz::new(service).await;
 no auth:
 ```rust
 let credentials = Credentials::builder().no_credentials().build().await.unwrap();
-let service = GoogleAuthz::builder(service).credentials(credentials).build().await;
+let service = GoogleAuthz::builder(service).credentials(credentials).build().await.unwrap();
 ```
 
 api key:
 ```rust
 let credentials = Credentials::builder().api_key(api_key).build().await.unwrap();
-let service = GoogleAuthz::builder(service).credentials(credentials).build().await;
+let service = GoogleAuthz::builder(service).credentials(credentials).build().await.unwrap();
 ```
 
 json:
 ```rust
 let credentials = Credentials::builder().json(json).build().await.unwrap();
-let service = GoogleAuthz::builder(service).credentials(credentials).build().await;
+let service = GoogleAuthz::builder(service).credentials(credentials).build().await.unwrap();
 ```
 
 json file:
 ```rust
 let credentials = Credentials::builder().json_file(json_file).build().await.unwrap();
-let service = GoogleAuthz::builder(service).credentials(credentials).build().await;
+let service = GoogleAuthz::builder(service).credentials(credentials).build().await.unwrap();
 ```
 
 metadata:
 ```rust
 let credentials = Credentials::builder().metadata(None).build().await.unwrap();
-let service = GoogleAuthz::builder(service).credentials(credentials).build().await;
+let service = GoogleAuthz::builder(service).credentials(credentials).build().await.unwrap();
 ```
 
 scope:
 ```rust
 let credentials = Credentials::builder().scopes(scopes).build().await.unwrap();
-let service = GoogleAuthz::builder(service).credentials(credentials).build().await;
+let service = GoogleAuthz::builder(service).credentials(credentials).build().await.unwrap();
 ```
 
 
@@ -90,7 +90,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let project = env::args().nth(1).expect("cargo run --bin tonic -- <GCP_PROJECT_ID>");
     let channel = Channel::from_static("https://pubsub.googleapis.com").connect().await?;
-    let channel = GoogleAuthz::new(channel).await;
+    let channel = GoogleAuthz::try_new(channel).await.unwrap();
 
     let mut client = PublisherClient::new(channel);
     let response = client

--- a/examples/src/tonic.rs
+++ b/examples/src/tonic.rs
@@ -8,9 +8,13 @@ use tonic::{transport::Channel, Request};
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let project = env::args().nth(1).expect("cargo run --bin tonic -- <GCP_PROJECT_ID>");
-    let channel = Channel::from_static("https://pubsub.googleapis.com").connect().await?;
-    let channel = GoogleAuthz::new(channel).await;
+    let project = env::args()
+        .nth(1)
+        .expect("cargo run --bin tonic -- <GCP_PROJECT_ID>");
+    let channel = Channel::from_static("https://pubsub.googleapis.com")
+        .connect()
+        .await?;
+    let channel = GoogleAuthz::try_new(channel).await?;
 
     let mut client = PublisherClient::new(channel);
     let response = client

--- a/src/auth/api_key.rs
+++ b/src/auth/api_key.rs
@@ -14,7 +14,7 @@ impl ApiKey {
     }
 
     #[inline]
-    pub fn add_query<B>(&self, req: Request<B>) -> Request<B> {
+    pub fn add_query<B>(&self, req: Request<B>) -> crate::auth::Result<Request<B>> {
         let (mut head, body) = req.into_parts();
         let s = {
             let mut s = head.uri.path().to_owned();
@@ -31,10 +31,10 @@ impl ApiKey {
         };
 
         let mut parts = head.uri.into_parts();
-        parts.path_and_query = Some(PathAndQuery::try_from(s).unwrap());
+        parts.path_and_query = Some(PathAndQuery::try_from(s)?);
 
-        head.uri = Uri::from_parts(parts).unwrap();
-        Request::from_parts(head, body)
+        head.uri = Uri::from_parts(parts)?;
+        Ok(Request::from_parts(head, body))
     }
 }
 

--- a/src/auth/error.rs
+++ b/src/auth/error.rs
@@ -11,6 +11,10 @@ pub enum Error {
     JsonDeserialize(serde_json::Error),
     #[error("token format error: {0:?}")]
     TokenFormat(crate::auth::oauth2::token::Response),
+    #[error("invalid uri: {0}")]
+    InvalidUri(#[from] hyper::http::uri::InvalidUri),
+    #[error("invalid uri parts: {0}")]
+    InvalidUriParts(#[from] hyper::http::uri::InvalidUriParts),
     #[cfg(not(feature = "tonic"))]
     #[error("uri schema error: {0:?}")]
     EnforceHttps(Option<String>),
@@ -18,3 +22,12 @@ pub enum Error {
 
 /// Wrapper for the `Result` type with an [`Error`](Error).
 pub(crate) type Result<T> = std::result::Result<T, Error>;
+
+/// Represents errors that can occur while building an Auth channel.
+#[derive(thiserror::Error, Debug)]
+pub enum AuthBuilderError {
+    #[error("encoding key error: {0}")]
+    EncodingKey(#[from] jsonwebtoken::errors::Error),
+    #[error("invalid uri: {0}")]
+    InvalidUri(#[from] hyper::http::uri::InvalidUri),
+}

--- a/src/auth/oauth2/mod.rs
+++ b/src/auth/oauth2/mod.rs
@@ -34,7 +34,11 @@ pub(super) struct Oauth2 {
 impl Oauth2 {
     pub fn new(fetcher: Box<dyn token::Fetcher>, max_retry: u8) -> Self {
         Self {
-            inner: Arc::new(RwLock::new(Inner { state: State::NotFetched, fetcher, max_retry })),
+            inner: Arc::new(RwLock::new(Inner {
+                state: State::NotFetched,
+                fetcher,
+                max_retry,
+            })),
         }
     }
 
@@ -47,14 +51,17 @@ impl Oauth2 {
 
     #[inline]
     pub fn add_header<B>(&self, mut req: Request<B>) -> Request<B> {
-        req.headers_mut().insert(AUTHORIZATION, self.inner.read().value());
+        req.headers_mut()
+            .insert(AUTHORIZATION, self.inner.read().value());
         req
     }
 }
 
 impl fmt::Debug for Oauth2 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Oauth2").field("inner", &self.inner).finish()
+        f.debug_struct("Oauth2")
+            .field("inner", &self.inner)
+            .finish()
     }
 }
 
@@ -112,8 +119,15 @@ impl Inner {
                         attempts: 1,
                     };
                 }
-                State::Fetching { ref mut future, attempts } => poll!(Fetching, future, attempts),
-                State::Refetching { ref mut future, attempts, ref last } => {
+                State::Fetching {
+                    ref mut future,
+                    attempts,
+                } => poll!(Fetching, future, attempts),
+                State::Refetching {
+                    ref mut future,
+                    attempts,
+                    ref last,
+                } => {
                     poll!(Refetching, future, attempts, last)
                 }
                 State::Fetched { ref current } => {
@@ -153,9 +167,18 @@ impl fmt::Debug for Inner {
 
 enum State {
     NotFetched,
-    Fetching { future: RefGuard<token::ResponseFuture>, attempts: u8 },
-    Refetching { future: RefGuard<token::ResponseFuture>, attempts: u8, last: token::Token },
-    Fetched { current: token::Token },
+    Fetching {
+        future: RefGuard<token::ResponseFuture>,
+        attempts: u8,
+    },
+    Refetching {
+        future: RefGuard<token::ResponseFuture>,
+        attempts: u8,
+        last: token::Token,
+    },
+    Fetched {
+        current: token::Token,
+    },
 }
 
 impl fmt::Debug for State {


### PR DESCRIPTION
Currently, the builder invokes `unwrap()` when parsing the RSA key, which causes panics whenever malformed RSA keys are provided. 

It's more safe to acknowledge that these functions are fallible and return a `Result`. This PR introduces a new Error variant, `AuthBuilderError`, and changes `new` to `try_new` for types such as `Metadata` and `ServiceAccount`.

Sorry my rustfmt made a lot of extra formatting changes. I can try to back them out if you prefer.